### PR TITLE
Finish swagger support integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ To build and test this project you can execute ``sbt test``. You can also use sb
 
 For the project checkstyle we are using [ScalaFMT](http://scalameta.org/scalafmt/). The code format will be evaluated after accepting any contribution to this repository using this tool. You can easily format your code changes automatically by executing ``sbt format``.
 
+## API documentation
+
+The REST API created in this project is documented using [Swagger](https://swagger.io/). Our build configuration will automatically generate a web-site with the API documentation based on the routing files if ``sbt run`` is executed. The documentation can be reviewed locally here: [http://localhost:9000/docs](http://localhost:9000/docs).
+   
+**The Swagger API description is generated into a file named ``swagger.json`` you can find in the path ``localhost:9000/swagger.json`` after running the app. This file can be used to generate client side code in many different languages automatically using [Swagger Code Gen](https://github.com/swagger-api/swagger-codegen).** You can easily install Swagger Code Gen from brew and execute the following command to generate, for example, the iOS API Client code:
+   
+```
+swagger-codegen generate -i target/swagger/swagger.json -l swift -o ~/Desktop/zolla-ios-api-client
+```
+
+The complete documentation of the plugin being used to generate the Swagger specs can be found [here](https://github.com/jakehschwartz/finatra-swagger). 
+
 ## Contributing
 
 If you would like to contribute code to this repository you can do so through GitHub by creating a new branch in the repository and sending a pull request or opening an issue. Please, remember that there are some requirements you have to pass before accepting your contribution:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "HaveANiceDay"
-version := "0.1"
-scalaVersion := "2.12.3"
+version := Versions.project
+scalaVersion := Versions.scala
 
 mainClass in (Compile,run) := Some("finatra.HaveANiceDayServerMain")
 
@@ -9,6 +9,7 @@ CommandAliases.addCommandAliases()
 
 libraryDependencies += "com.twitter" %% "finatra-http" % Versions.finatra
 libraryDependencies += "ch.qos.logback" % "logback-classic" % Versions.logback
+libraryDependencies += "com.jakehschwartz" %% "finatra-swagger" % Versions.finatraSwagger
 libraryDependencies += "com.twitter" %% "finatra-http" % Versions.finatra % Test classifier "tests"
 libraryDependencies += "ch.qos.logback" % "logback-classic" % Versions.logback % Test
 libraryDependencies += "com.twitter" %% "finatra-http" % Versions.finatra % Test

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,7 +1,9 @@
 object Versions {
-
+  val project = "0.1"
+  val scala = "2.12.3"
   val finatra = "2.13.0"
   val logback = "1.2.3"
+  val finatraSwagger = "2.10.0"
   val guice = "4.0"
   val scalatest = "3.0.1"
   val mockito = "1.9.5"

--- a/src/main/scala/finatra/HaveANiceDayServer.scala
+++ b/src/main/scala/finatra/HaveANiceDayServer.scala
@@ -1,21 +1,29 @@
 package finatra
 
+import com.jakehschwartz.finatra.swagger.DocsController
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
 import com.twitter.finatra.http.routing.HttpRouter
 import finatra.controllers.RootController
+import finatra.swagger.HaveANiceDaySwaggerModule
+import io.swagger.models.Swagger
 
 object HaveANiceDayServerMain extends HaveANiceDayServer
+
+object HaveANiceDaySwagger extends Swagger
 
 class HaveANiceDayServer extends HttpServer {
 
   override protected def defaultFinatraHttpPort = ":9000"
+
+  override protected def modules = Seq(HaveANiceDaySwaggerModule)
 
   override protected def configureHttp(router: HttpRouter): Unit =
     router
       .filter[LoggingMDCFilter[Request, Response]]
       .filter[TraceIdMDCFilter[Request, Response]]
       .filter[CommonFilters]
+      .add[DocsController]
       .add[RootController]
 }

--- a/src/main/scala/finatra/controllers/RootController.scala
+++ b/src/main/scala/finatra/controllers/RootController.scala
@@ -1,11 +1,18 @@
 package finatra.controllers
 
+import com.google.inject.Inject
+import com.jakehschwartz.finatra.swagger.SwaggerController
 import com.twitter.finagle.http.Request
-import com.twitter.finatra.http.Controller
+import io.swagger.models.Swagger
 
-class RootController extends Controller {
+class RootController @Inject()(s: Swagger) extends SwaggerController {
+  implicit protected val swagger: Swagger = s
 
-  get("/") { _: Request =>
+  getWithDoc("/") { o =>
+    o.tag("Root")
+      .summary("Root endpoint created to simply return 200 status code if the service is running.")
+      .responseWith(200)
+  } { _: Request =>
     response.ok
   }
 }

--- a/src/main/scala/finatra/swagger/HaveANiceDaySwaggerModule.scala
+++ b/src/main/scala/finatra/swagger/HaveANiceDaySwaggerModule.scala
@@ -1,0 +1,20 @@
+package finatra.swagger
+
+import com.google.inject.{Provides, Singleton}
+import com.jakehschwartz.finatra.swagger.SwaggerModule
+import io.swagger.models.{Info, Swagger}
+
+object HaveANiceDaySwaggerModule extends SwaggerModule {
+
+  @Singleton
+  @Provides
+  def swagger: Swagger = {
+    val swagger = new Swagger()
+    val info = new Info()
+      .title("Have a nice day API")
+      .description(
+        "Have a nice API swagger documentation. More information can be found at https://github.com/pedrovgs/haveaniceday.")
+      .version("1.0")
+    swagger.info(info)
+  }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Add swagger to the project.

### :tophat: What is the goal?

Based on the swagger documentation generated in this project we'll be able to consume our service from different clients easily. If @delr3ves needs to generate client-side code we can use swagger-code-gen 😃 

### How is it being implemented?

Adding a dependency to generate swagger documentation easily and documenting our first endpoint easily.

### How can it be tested?

Checkout this branch, execute ``sbt run`` and open [localhost:9000/docs](localhost:9000/docs). You should be able to see a screen like this:

![captura de pantalla 2017-09-18 a las 23 01 39](https://user-images.githubusercontent.com/4030704/30564485-59d398bc-9cc5-11e7-8d44-f1302e1db158.png)

