### PR TITLE
Add two additional twitter accounts and make this value configurable by environment variables

### DIFF
--- a/src/main/resources/smilesGenerator.conf
+++ b/src/main/resources/smilesGenerator.conf
@@ -1,4 +1,5 @@
-twitterAccounts = ["818887507169247232"]
+twitterAccounts = ["818887507169247232", "114685387", "129845242"]
+twitterAccounts = ${?SMILES_EXTRACTION_TWITTER_ACCOUNTS}
 scheduleTasks = false
 scheduleTasks = ${?SCHEDULE_SMILE_TASKS}
 extractionSchedule = "0 0 7 ? * *"


### PR DESCRIPTION
### :tophat: What is the goal?

Update our project configuration to be able to change the source accounts used to extract smiles easily.

### How is it being implemented?

We've overridden the config value where the twitter accounts are declared and we will use [this](https://github.com/lightbend/config/issues/320) feature to be able to declare a list of accounts in AWS.

### How can it be tested?

It's tested automatically.