### PR TITLE
Improve how the generated smile is selected

### DIFF
--- a/src/main/scala/com/github/pedrovgs/haveaniceday/smiles/storage/SmilesRepository.scala
+++ b/src/main/scala/com/github/pedrovgs/haveaniceday/smiles/storage/SmilesRepository.scala
@@ -26,13 +26,10 @@ class SmilesRepository @Inject()(database: Database) {
     database.db.run(DBIO.sequence(inserts).transactionally).map(asDomain)
   }
 
-  def getNextMostRatedNotSentSmile(): Future[Option[Smile]] = {
+  def getNextMostRatedNotSentSmiles(numberOfSmiles: Int = 100): Future[Seq[Smile]] = {
     val query =
-      SmilesTable.filterNot(_.sent).sortBy(row => (row.numberOfLikes.desc, row.id.desc)).take(1).result.headOption
-    database.db.run(query).map {
-      case Some(row) => Some(row)
-      case _         => None
-    }
+      SmilesTable.filterNot(_.sent).sortBy(row => (row.numberOfLikes.desc, row.id.desc)).take(numberOfSmiles).result
+    database.db.run(query).map(asDomain)
   }
 
   def getLastSmileSent(): Future[Option[Smile]] = {


### PR DESCRIPTION
### :tophat: What is the goal?

Improve how the generated smile is selected using a random smile between the most 100 top rated smiles instead of the most rated smile.

### How is it being implemented?

We've changed the repository code to return the 100 most rated smiles sorted by the number of likes and before sending the smile we've updated the code to pick one of them randomly.

### How can it be tested?

Automatically 🤖 